### PR TITLE
bump node container version to 18.20.3-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.6.2-stretch-slim
+FROM node:18.20.3-buster-slim
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Node 16 is being deprecated for GitHub Actions.
Updating action to use Node 18.